### PR TITLE
Remove deprecated alias `numpy.bool8` 

### DIFF
--- a/CIMtools/preprocessing/fingerprint.py
+++ b/CIMtools/preprocessing/fingerprint.py
@@ -17,7 +17,10 @@
 #  along with this program; if not, see <https://www.gnu.org/licenses/>.
 #
 from CGRtools.containers import MoleculeContainer, CGRContainer
-from numpy import zeros, bool8
+try:
+    from numpy import zeros, bool8
+except ImportError:
+    from numpy import zeros, bool_ as bool8
 from hashlib import md5
 from pandas import DataFrame
 from sklearn.base import BaseEstimator, TransformerMixin

--- a/environment.yml
+++ b/environment.yml
@@ -15,4 +15,5 @@ dependencies:
   - pip:
     - CGRtools
     - StructureFingerprint
+    - setuptools
     - .

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if find_spec('wheel'):
 
 setup(
     name='CIMtools',
-    version='4.0.14',
+    version='4.0.15',
     packages=find_packages(),
     url='https://github.com/cimm-kzn/CIMtools',
     license='GPLv3',
@@ -83,6 +83,7 @@ setup(
                  'Programming Language :: Python :: 3.10',
                  'Programming Language :: Python :: 3.11',
                  'Programming Language :: Python :: 3.12',
+                 'Programming Language :: Python :: 3.13',                 
                  'Topic :: Scientific/Engineering',
                  'Topic :: Scientific/Engineering :: Chemistry',
                  'Topic :: Scientific/Engineering :: Information Analysis',


### PR DESCRIPTION
…cated, since numpy 2.0.0 it is removed)

`numpy.bool8` is just a deprecated alias of [`numpy.bool_`](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool_).